### PR TITLE
Update to method used to determine in-range to target

### DIFF
--- a/API.lua
+++ b/API.lua
@@ -16,8 +16,7 @@ function GetInteractionTargetName()
 
     if interactionExists and interactableName ~= "" and interactableName ~= nil then
         return interactableName
-    elseif GetUnitName("reticleover") ~= "" and not IsUnitPlayer("reticleover") and (GetDistanceToReticleOverTarget() < 350) then -- TODO: Distance check "GetDistanceToReticleOverTarget() < 500"?
-        LCQ_DBG:Debug("Interaction target has no range check!")
+    elseif GetUnitName("reticleover") ~= "" and not IsUnitPlayer("reticleover") then
         return GetUnitName("reticleover")
     elseif PLAYER_TO_PLAYER:HasTarget() then
         return PLAYER_TO_PLAYER.currentTargetDisplayName
@@ -30,15 +29,13 @@ function GetDistanceToReticleOverTarget()
     if not DoesUnitExist("reticleover") then return -1 end
     local _, x1, y1, z1 = GetUnitWorldPosition("player")
     local _, x2, y2, z2 = GetUnitWorldPosition("reticleover")
-    local dx, dy, dz = x2 - x1, y2 - y1, z2 - z1
-    local d = math.sqrt(dx*dx + dy*dy + dz*dz)
+
     --LCQ_DBG:Log("Distance to reticleover: <<1>>", LCQ_DBG_ALWAYS_SHOW, tostring(d))
-    return d
+    return zo_distance3D(x1, y1, z1, x2, y2, z2) --Returns (number) 3D distance --Units will be in whatever units you pass in
 end
 
 function GetDistanceToPoint(x, y, z)
     x, y, z = x or 0, y or 0, z or 0
     local _, x1, y1, z1 = GetUnitWorldPosition("player")
-    local dx, dy, dz = x - x1, y - y1, z - z1
-    return math.sqrt(dx*dx + dy*dy + dz*dz)
+    return zo_distance3D(x, y, z, x1, y1, z1) --Returns (number) 3D distance --Units will be in whatever units you pass in
 end

--- a/Reticle.lua
+++ b/Reticle.lua
@@ -3,9 +3,6 @@ local LibCustomQuest = LibCustomQuest or {}
 local function ReticleOverrides()
     function LCQ_TEST_RETICLE:IsInteractableFoundNotFound(interactionExists)
         local name = GetInteractionTargetName()
-        if (not name or name == "") and not IsUnitPlayer("reticleover") then
-            name = GetUnitName("reticleover")
-        end
 
         if interactionExists and LCQ_INTERACTIONLISTENER:IsTargetRegisteredInteraction(name) then
             local result, name = true, name


### PR DESCRIPTION
- zo_distance3D used for 3D distance
- GetDistanceToReticleOverTarget() deprecated, but kept the function as it's referenced in debugs